### PR TITLE
MRC-440: Allow specifying context root id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ r_packages:
 after_success:
   - Rscript -e 'covr::codecov()'
 r_github_packages:
-  mrc-ide/provisionr
+  - mrc-ide/provisionr
 
 addons:
   postgresql: "9.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,16 @@ after_success:
   - Rscript -e 'covr::codecov()'
 r_github_packages:
   mrc-ide/provisionr
+
+addons:
+  postgresql: "9.5"
+  apt:
+    packages:
+      - libapparmor-dev
+      - libhiredis-dev
+      - libpq-dev
+      - redis-server
+
+services:
+  - postgresql
+  - redis-server

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,15 +9,18 @@ LazyData: true
 URL: https://github.com/mrc-ide/context
 BugReports: https://github.com/mrc-ide/context/issues
 Depends:
-    R (>= 3.2.2)
+    R (>= 3.2.0)
 Imports:
     crayon,
     ids,
     storr (>= 1.1.1)
 Suggests:
+    DBI,
+    RPostgres,
     knitr,
     parallel,
     provisionr (>= 0.1.8),
+    redux,
     rmarkdown,
     testthat
 RoxygenNote: 5.0.1

--- a/R/context.R
+++ b/R/context.R
@@ -34,12 +34,22 @@
 ##'   printed with the context in some situations (such as
 ##'   \code{\link{context_info}})
 ##'
+##' @param root_id Force a context root id.  This is intended for
+##'   advanced use only.  By settting the root id, two contexts
+##'   created with storage in different file locations (\code{path})
+##'   will get the same id.  This is required for using a
+##'   server-hosted database to share a context between different
+##'   physical machines (or different docker containers).  The id, if
+##'   provided, must be compatible with \code{ids::random_id()} -
+##'   i.e., a 32 character hex string.  This option can be left alone
+##'   in most situations.
+##'
 ##' @export
 context_save <- function(path, packages = NULL, sources = NULL,
                          package_sources = NULL, envir = NULL,
                          storage_type = NULL, storage_args = NULL,
-                         name = NULL) {
-  root <- context_root_init(path, storage_type, storage_args)
+                         name = NULL, root_id = NULL) {
+  root <- context_root_init(path, storage_type, storage_args, root_id)
   db <- root$db
   if (!is.null(package_sources)) {
     assert_is(package_sources, "package_sources")

--- a/R/context_root.R
+++ b/R/context_root.R
@@ -56,6 +56,9 @@ context_db_get <- function(root) {
 context_db_init <- function(path, type, args, id = NULL) {
   if (!is.null(id)) {
     assert_scalar_character(id)
+    if (!grepl("^[[:xdigit:]]{32}$", id)) {
+      stop("id, if given, must be a 32 character hex string", call. = FALSE)
+    }
   }
   f_id <- path_id(path)
   f_config <- path_config(path)

--- a/R/context_root.R
+++ b/R/context_root.R
@@ -21,7 +21,8 @@ context_root_get <- function(root, db = NULL) {
   root
 }
 
-context_root_init <- function(path, storage_type = NULL, storage_args = NULL) {
+context_root_init <- function(path, storage_type = NULL, storage_args = NULL,
+                              id = NULL) {
   fv <- path_version(path)
   written <- package_version(if (file.exists(fv)) readLines(fv) else "0.0")
   installed <- packageVersion("context")
@@ -34,7 +35,7 @@ context_root_init <- function(path, storage_type = NULL, storage_args = NULL) {
   } else if (written > installed) {
     stop("context version conflict; local is outdated")
   }
-  db <- context_db_init(path, storage_type, storage_args)
+  db <- context_db_init(path, storage_type, storage_args, id)
   root <- context_root(path, db)
   if (written > numeric_version("0.0") && written < numeric_version("0.1.0")) {
     context_upgrade_0_1_0(root)
@@ -52,10 +53,20 @@ context_db_get <- function(root) {
   }
 }
 
-context_db_init <- function(path, type, args) {
+context_db_init <- function(path, type, args, id = NULL) {
+  if (!is.null(id)) {
+    assert_scalar_character(id)
+  }
   f_id <- path_id(path)
   f_config <- path_config(path)
   if (file.exists(f_id)) {
+    if (!is.null(id)) {
+      prev <- readLines(f_id)
+      if (!identical(id, prev)) {
+        stop(sprintf("Given id '%s' and stored id '%s' differ", id, prev),
+             call. = FALSE)
+      }
+    }
     config <- readRDS(f_config)
     if (!is.null(type) && !identical(type, config$type)) {
       config_type <- if (is.function(config$type)) "user" else config$type
@@ -85,7 +96,7 @@ context_db_init <- function(path, type, args) {
     }
     db <- context_db_open(path, config, FALSE)
   } else {
-    id <- ids::random_id()
+    id <- id %||% ids::random_id()
     context_log("init:id", id)
     writeLines(id, f_id)
     ## TODO: do some sanity checking here; 'type' must be a function or string

--- a/R/task_bulk.R
+++ b/R/task_bulk.R
@@ -83,7 +83,7 @@ bulk_prepare_expression_X <- function(X, do_call, use_names) {
       lens <- lengths(X)
       ## Here, support recycling out scalars
       ul <- unique(lens)
-      if (ul == 2L && min(ul) == 1L) {
+      if (length(ul) == 2L && min(ul) == 1L) {
         n <- max(lens)
         X[lens == 1L] <- lapply(X[lens == 1L], rep_len, n)
         ul <- lens <- n

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 # DO NOT CHANGE the "init" and "install" sections below
 
+environment:
+  global:
+    R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+
 # Download script file from GitHub
 init:
   ps: |
@@ -14,6 +18,7 @@ install:
 
 build_script:
   - travis-tool.sh install_deps
+  - travis-tool.sh install_github mrc-ide/provisionr
 
 test_script:
   - travis-tool.sh run_tests

--- a/man/context_save.Rd
+++ b/man/context_save.Rd
@@ -6,7 +6,7 @@
 \usage{
 context_save(path, packages = NULL, sources = NULL,
   package_sources = NULL, envir = NULL, storage_type = NULL,
-  storage_args = NULL, name = NULL)
+  storage_args = NULL, name = NULL, root_id = NULL)
 }
 \arguments{
 \item{path}{Path to save the context in}
@@ -41,8 +41,17 @@ to use.  Options are \code{"rds"} (the default) and
 \item{name}{An optional name for the context.  This will be
 printed with the context in some situations (such as
 \code{\link{context_info}})}
+
+\item{root_id}{Force a context root id.  This is intended for
+advanced use only.  By settting the root id, two contexts
+created with storage in different file locations (\code{path})
+will get the same id.  This is required for using a
+server-hosted database to share a context between different
+physical machines (or different docker containers).  The id, if
+provided, must be compatible with \code{ids::random_id()} -
+i.e., a 32 character hex string.  This option can be left alone
+in most situations.}
 }
 \description{
 Save a context
 }
-

--- a/tests/testthat/test-context-root.R
+++ b/tests/testthat/test-context-root.R
@@ -134,3 +134,9 @@ test_that("verify id when creating context root with fixed id", {
     context_root_init(path, NULL, NULL, ids::random_id()),
     "Given id '[[:xdigit:]]+' and stored id '[[:xdigit:]]+' differ")
 })
+
+test_that("verify id format", {
+  expect_error(
+    context_root_init(tempfile(), NULL, NULL, ids::random_id(bytes = 4)),
+    "id, if given, must be a 32 character hex string")
+})

--- a/tests/testthat/test-context-root.R
+++ b/tests/testthat/test-context-root.R
@@ -113,3 +113,24 @@ test_that("driver packages", {
   expect_equal(length(id2), 2)
   expect_true(is_id(id2[[2]]))
 })
+
+test_that("create context root with fixed id", {
+  id <- ids::random_id()
+  path <- tempfile()
+
+  res <- context_root_init(path, NULL, NULL, id)
+  expect_equal(res$id, id)
+  expect_equal(res$path, path)
+
+  res <- context_root_init(path, NULL, NULL, id)
+  expect_equal(res$id, id)
+  expect_equal(res$path, path)
+})
+
+test_that("verify id when creating context root with fixed id", {
+  path <- tempfile()
+  res <- context_root_init(path, NULL, NULL)
+  expect_error(
+    context_root_init(path, NULL, NULL, ids::random_id()),
+    "Given id '[[:xdigit:]]+' and stored id '[[:xdigit:]]+' differ")
+})

--- a/tests/testthat/test-context.R
+++ b/tests/testthat/test-context.R
@@ -343,3 +343,15 @@ test_that("local", {
   expect_true("loop" %in% ls(parent.env(res$envir)))
   expect_identical(e2, parent.env(res$envir))
 })
+
+test_that("force root id", {
+  id <- ids::random_id()
+
+  ctx1 <- context_save(tempfile(), root_id = id)
+  ctx2 <- context_save(tempfile(), root_id = id)
+  expect_equal(ctx1$root$id, id)
+  expect_equal(ctx2$root$id, id)
+
+  expect_equal(ctx1$id, ctx2$id)
+  expect_false(ctx1$name == ctx2$name)
+})

--- a/tests/testthat/test-tasks-bulk.R
+++ b/tests/testthat/test-tasks-bulk.R
@@ -58,7 +58,7 @@ test_that("prepare; uneven length lists", {
 
   ## Error case
   expect_error(
-    bulk_prepare_expression(list(1, 1:2), quote(foo), NULL, TRUE, TRUE),
+    bulk_prepare_expression(list(1, 1:2, 1:3), quote(foo), NULL, TRUE, TRUE),
     "Every element of 'X' must have the same length")
 })
 
@@ -202,9 +202,6 @@ test_that("function-by-value", {
 })
 
 test_that("heterogenous list do_call fails", {
-  expect_error(
-    bulk_prepare_expression_X(list(list(a = 1), list(a = 1, b = 2)), TRUE),
-    "Every element of 'X' must have the same length")
   expect_error(
     bulk_prepare_expression_X(list(list(a = 1), list(b = 2)), TRUE),
     "Elements of 'X' must have the same names")


### PR DESCRIPTION
This PR will allow a root id to be provided when creating a context.  The rationale is explained in the documentation:

> Force a context root id.  This is intended for advanced use only.  By settting the root id, two contexts created with storage in different file locations (\code{path}) will get the same id.  This is required for using a server-hosted database to share a context between different physical machines (or different docker containers).  The id, if provided, must be compatible with \code{ids::random_id()} - i.e., a 32 character hex string.  This option can be left alone in most situations.

This is required to support mrc-439 so that rrq will work nicely without shared disks.

Sorry, this PR lacks a lot of broader context - this is a package that underlies a lot of the cluster tools for specifying and creating a computational environment repeatedly, as well as for serialising the expressions to run remotely